### PR TITLE
Add HKDF function

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,6 @@ jobs:
         if: "steps.cached-poetry-dependencies.outputs.cache-hit != 'true'"
         run: "poetry install --no-interaction --no-root"
       # Run linters
-      - name: "linting: black"
-        run: "poetry run invoke black"
       - name: "linting: flake8"
         run: "poetry run invoke flake8"
       - name: "linting: pylint"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,11 @@
 ---
 name: "CI"
 on: # yamllint disable-line rule:truthy rule:comments
-  - "push"
-  - "pull_request"
+  push:
+    branches:
+      - "main"
+      - "develop"
+  pull_request: ~
 
 jobs:
   linting:

--- a/crypto_labs/hkdf.py
+++ b/crypto_labs/hkdf.py
@@ -1,10 +1,6 @@
 """Simple implementation of basic HMAC-based Extract-and-Expand Key Derivative Functions (HKDF)."""
 
 import hmac
-import hashlib
-
-# import struct
-import sys
 
 
 def hkdf_extract(salt: bytes, input_key_material: bytes, hash_function: str) -> bytes:

--- a/crypto_labs/hkdf.py
+++ b/crypto_labs/hkdf.py
@@ -28,9 +28,7 @@ def hkdf_extract(salt: bytes, input_key_material: bytes, hash_function: str) -> 
     return hmac.new(salt, input_key_material, hash_function).digest()
 
 
-def hkdf_expand(
-    pseudo_random_key: bytes, info: bytes, key_length: int, hash_function: str
-) -> bytes:
+def hkdf_expand(pseudo_random_key: bytes, info: bytes, key_length: int, hash_function: str) -> bytes:
     """HKDF Expand function that uses HMAC as the pseudorandom function.
 
     Args:
@@ -49,9 +47,7 @@ def hkdf_expand(
 
     # Check if the expanded key's desired length is too long based on RFC 5869
     if key_length > 255 * hash_length:
-        raise ValueError(
-            "Key length too long. Cannot expand output keying material bigger than `255 * Hash's length`."
-        )
+        raise ValueError("Key length too long. Cannot expand output keying material bigger than `255 * Hash's length`.")
 
     # The output of the HMAC function is the expanded key
     while len(expanded_key) < key_length:

--- a/crypto_labs/hkdf.py
+++ b/crypto_labs/hkdf.py
@@ -1,7 +1,28 @@
 """Simple implementation of basic HMAC-based Extract-and-Expand Key Derivative Functions (HKDF)."""
 
-# import hmac
+import hmac
 # import struct
+
+
+def hkdf_extract(salt: bytes, input_key_material: bytes, hash_function: str) -> bytes:
+    """HKDF Extract function that uses HMAC as the pseudorandom function.
+
+    Args:
+        salt (bytes): The salt to use for the HMAC function.
+        input_key_material (bytes): The input key material to use.
+        hash_function (str): The hash function to use.
+
+    Returns:
+        bytes: The extracted key.
+    """
+    # If a salt is not provided, set it to a string of zeros("0").
+    # The length of the string should be the length of the hash function's output.
+    if not salt:
+        hash_length = hmac.new(b"", b"", hash_function).digest_size
+        salt = bytes("0" * hash_length, "utf-8")
+
+    # The result of the HMAC function is the extracted key
+    return hmac.new(salt, input_key_material, hash_function).digest()
 
 
 # TODO add HKDF implementation

--- a/crypto_labs/hkdf.py
+++ b/crypto_labs/hkdf.py
@@ -25,6 +25,44 @@ def hkdf_extract(salt: bytes, input_key_material: bytes, hash_function: str) -> 
     return hmac.new(salt, input_key_material, hash_function).digest()
 
 
+def hkdf_expand(pseudo_random_key: bytes, info: bytes, key_length: int, hash_function: str) -> bytes:
+    """HKDF Expand function that uses HMAC as the pseudorandom function.
+
+    Args:
+        pseudo_random_key (bytes): The pseudo-random key to use for the HMAC function.
+        info (bytes): The context and application specific information.
+        key_length (int): The length of the output keying material in bytes.
+        hash_function (str): The hash function to use.
+
+    Returns:
+        bytes: The expanded key.
+    """
+    hash_length = hmac.new(b"", b"", hash_function).digest_size
+    if key_length > 255 * hash_length:
+        raise ValueError("Key length too long. Cannot expand output keying material bigger than `255 * Hash's length`.")
+
+    # The number of blocks to use for the HMAC function
+    num_blocks = key_length // hash_length + (1 if key_length % hash_length else 0)
+    block_result = b""
+    # The expanded key
+    expanded_key = b""
+    block_number = 1
+
+    # while len(expanded_key) < key_length:
+    #     block_result = hmac.new(pseudo_random_key, block_result + info + bytes([block_number]), hash_function).digest()
+    #     expanded_key += block_result
+    #     block_number += 1
+
+
+    # The output of the HMAC function is the expanded key
+    for i in range(num_blocks):
+        print(i)
+        block_result = hmac.new(pseudo_random_key, block_result + info + bytes([i + 1]), hash_function).digest()
+        expanded_key += block_result
+
+    return expanded_key[:key_length]
+
+
 # TODO add HKDF implementation
 def hkdf():
     """Have to implement HKDF funciton."""

--- a/crypto_labs/hkdf.py
+++ b/crypto_labs/hkdf.py
@@ -2,8 +2,10 @@
 
 import hmac
 import hashlib
+
 # import struct
 import sys
+
 
 def hkdf_extract(salt: bytes, input_key_material: bytes, hash_function: str) -> bytes:
     """HKDF Extract function that uses HMAC as the pseudorandom function.
@@ -20,13 +22,15 @@ def hkdf_extract(salt: bytes, input_key_material: bytes, hash_function: str) -> 
     # The length of the string should be the length of the hash function's output.
     if not salt:
         hash_length = hmac.new(b"", b"", hash_function).digest_size
-        salt = bytes("0" * hash_length, "utf-8")
+        salt = bytes((0,) * hash_length)
 
     # The result of the HMAC function is the extracted key
     return hmac.new(salt, input_key_material, hash_function).digest()
 
 
-def hkdf_expand(pseudo_random_key: bytes, info: bytes, key_length: int, hash_function: str) -> bytes:
+def hkdf_expand(
+    pseudo_random_key: bytes, info: bytes, key_length: int, hash_function: str
+) -> bytes:
     """HKDF Expand function that uses HMAC as the pseudorandom function.
 
     Args:
@@ -45,11 +49,17 @@ def hkdf_expand(pseudo_random_key: bytes, info: bytes, key_length: int, hash_fun
 
     # Check if the expanded key's desired length is too long based on RFC 5869
     if key_length > 255 * hash_length:
-        raise ValueError("Key length too long. Cannot expand output keying material bigger than `255 * Hash's length`.")
+        raise ValueError(
+            "Key length too long. Cannot expand output keying material bigger than `255 * Hash's length`."
+        )
 
     # The output of the HMAC function is the expanded key
     while len(expanded_key) < key_length:
-        block_result = hmac.new(pseudo_random_key, block_result + info + bytes([block_number]), hash_function).digest()
+        block_result = hmac.new(
+            pseudo_random_key,
+            block_result + info + bytes([block_number]),
+            hash_function,
+        ).digest()
         expanded_key += block_result
         block_number += 1
 

--- a/crypto_labs/pbkdf.py
+++ b/crypto_labs/pbkdf.py
@@ -21,7 +21,7 @@ def pbkdf2(password: bytes, salt: bytes, count: int, key_length: int, hash_funct
     block_number = 1
     hash_length = hmac.new(b"", b"", hash_function).digest_size
 
-    # Check if the derived key length is too long based on RFC 2898
+    # Check if the derived key's expected length is too long based on RFC 2898
     if key_length > (2**32 - 1) * hash_length:
         raise ValueError("Derived key too long")
 

--- a/crypto_labs/tests/test_hkdf.py
+++ b/crypto_labs/tests/test_hkdf.py
@@ -1,31 +1,72 @@
 """Test case for hkdf module."""
 
 import unittest
-
+import hashlib
 # from hashlib import pbkdf2_hmac
-from crypto_labs.hkdf import hkdf_extract, hkdf_expand
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-from cryptography.hazmat.primitives import hashes
+from crypto_labs.hkdf import hkdf_extract, hkdf_expand, hkdf_expand_tupou
+# from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+# from cryptography.hazmat.primitives import hashes
+
 
 class TestHKDF(unittest.TestCase):
     """Test case for HKDF module."""
 
+    # def test_hkdf_expand(self):
+    #     """Test that hkdf_extract function returns the expected key."""
+    #     prk = b"pseudorandomkey"
+    #     info = b"makis"
 
-    def test_hkdf_expand(self):
-        """Test that hkdf_extract function returns the expected key."""
-        prk = b"pseudorandomkey"
-        info=b"makis"
+    #     key = hkdf_expand(prk, info, 5, "sha256")
+    #     self.assertEqual(key, HKDF(hashes.SHA256(), 5, prk, info).derive(info))
 
-        key = hkdf_expand(prk, info, 5, "sha256")
-        self.assertEqual(key, HKDF(hashes.SHA256(), 5, prk, info).derive(info))
+    def hex_to_bytes(self, hex_string):
+        return bytes.fromhex(hex_string[2:])
 
+    def test_hkdf_against_rfc_vectors(self):
+        """Test that hkdf functions returns the expected results based on RFC-5869 test vectors.
 
+        HKDF Test Vectors: https://datatracker.ietf.org/doc/html/rfc5869.
+        """
+        test_vectors = [
+            {
+                "hash": "sha256",
+                "ikm": "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+                "salt": "0x000102030405060708090a0b0c",
+                "info": "0xf0f1f2f3f4f5f6f7f8f9",
+                "L": 42,
+                "PRK": "0x077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5",
+                "OKM": "0x3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
+            },
+            {
+                "hash": "sha256",
+                "ikm": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
+                "salt": "0x606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+                "info": "0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+                "L": 82,
+                "PRK": "0x06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244",
+                "OKM": "0xb11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87",
+            },
+        ]
 
+        for test_vector in test_vectors:
+            pseudo_random_key = hkdf_extract(
+                salt=self.hex_to_bytes(test_vector["salt"]),
+                input_key_material=self.hex_to_bytes(test_vector["ikm"]),
+                hash_function=test_vector["hash"],
+            )
+            output_keying_material = hkdf_expand(
+                pseudo_random_key=pseudo_random_key,
+                info=self.hex_to_bytes(test_vector["info"]),
+                key_length=test_vector["L"],
+                hash_function=test_vector["hash"],
+            )
+
+            self.assertEqual(pseudo_random_key, self.hex_to_bytes(test_vector["PRK"]))
+            self.assertEqual(output_keying_material, self.hex_to_bytes(test_vector["OKM"]))
 
     # TODO: add test cases for HKDF
     def test_hkdf(self):
         """Test that hkdf function returns the expected key."""
-
 
 
 if __name__ == "__main__":

--- a/crypto_labs/tests/test_hkdf.py
+++ b/crypto_labs/tests/test_hkdf.py
@@ -2,8 +2,11 @@
 
 import unittest
 import hashlib
+
 # from hashlib import pbkdf2_hmac
-from crypto_labs.hkdf import hkdf_extract, hkdf_expand, hkdf_expand_tupou
+from crypto_labs.hkdf import hkdf_extract, hkdf_expand
+from crypto_labs.hkdf_copy import hkdf_extract_tupou, hkdf_expand_tupou
+
 # from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 # from cryptography.hazmat.primitives import hashes
 
@@ -20,7 +23,7 @@ class TestHKDF(unittest.TestCase):
     #     self.assertEqual(key, HKDF(hashes.SHA256(), 5, prk, info).derive(info))
 
     def hex_to_bytes(self, hex_string):
-        return bytes.fromhex(hex_string[2:])
+        return bytes.fromhex(hex_string[2:]) if hex_string else bytes.fromhex("")
 
     def test_hkdf_against_rfc_vectors(self):
         """Test that hkdf functions returns the expected results based on RFC-5869 test vectors.
@@ -46,6 +49,51 @@ class TestHKDF(unittest.TestCase):
                 "PRK": "0x06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244",
                 "OKM": "0xb11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87",
             },
+            {
+                "hash": "sha256",
+                "ikm": "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+                "salt": "",
+                "info": "",
+                "L": 42,
+                "PRK": "0x19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04",
+                "OKM": "0x8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8",
+            },
+            {
+                "hash": "sha1",
+                "ikm": "0x0b0b0b0b0b0b0b0b0b0b0b",
+                "salt": "0x000102030405060708090a0b0c",
+                "info": "0xf0f1f2f3f4f5f6f7f8f9",
+                "L": 42,
+                "PRK": "0x9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243",
+                "OKM": "0x085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896",
+            },
+            {
+                "hash": "sha1",
+                "ikm": "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f",
+                "salt": "0x606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+                "info": "0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+                "L": 82,
+                "PRK": "0x8adae09a2a307059478d309b26c4115a224cfaf6",
+                "OKM": "0x0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e927336d0441f4c4300e2cff0d0900b52d3b4",
+            },
+            {
+                "hash": "sha1",
+                "ikm": "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+                "salt": "",
+                "info": "",
+                "L": 42,
+                "PRK": "0xda8c8a73c7fa77288ec6f5e7c297786aa0d32d01",
+                "OKM": "0x0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918",
+            },
+            {
+                "hash": "sha1",
+                "ikm": "0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c",
+                "salt": "",
+                "info": "",
+                "L": 42,
+                "PRK": "0x2adccada18779e7c2077ad2eb19d3f3e731385dd",
+                "OKM": "0x2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48",
+            },
         ]
 
         for test_vector in test_vectors:
@@ -60,9 +108,10 @@ class TestHKDF(unittest.TestCase):
                 key_length=test_vector["L"],
                 hash_function=test_vector["hash"],
             )
-
             self.assertEqual(pseudo_random_key, self.hex_to_bytes(test_vector["PRK"]))
-            self.assertEqual(output_keying_material, self.hex_to_bytes(test_vector["OKM"]))
+            self.assertEqual(
+                output_keying_material, self.hex_to_bytes(test_vector["OKM"])
+            )
 
     # TODO: add test cases for HKDF
     def test_hkdf(self):

--- a/crypto_labs/tests/test_hkdf.py
+++ b/crypto_labs/tests/test_hkdf.py
@@ -109,9 +109,7 @@ class TestHKDF(unittest.TestCase):
                 hash_function=test_vector["hash"],
             )
             self.assertEqual(pseudo_random_key, self.hex_to_bytes(test_vector["PRK"]))
-            self.assertEqual(
-                output_keying_material, self.hex_to_bytes(test_vector["OKM"])
-            )
+            self.assertEqual(output_keying_material, self.hex_to_bytes(test_vector["OKM"]))
 
     # TODO: add test cases for HKDF
     def test_hkdf(self):

--- a/crypto_labs/tests/test_hkdf.py
+++ b/crypto_labs/tests/test_hkdf.py
@@ -3,23 +3,29 @@
 import unittest
 
 # from hashlib import pbkdf2_hmac
-
-# from crypto_labs.hkdf import hkdf
-
+from crypto_labs.hkdf import hkdf_extract, hkdf_expand
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
 
 class TestHKDF(unittest.TestCase):
     """Test case for HKDF module."""
 
 
-    def test_hkdf_extract(self):
+    def test_hkdf_expand(self):
         """Test that hkdf_extract function returns the expected key."""
-        # TODO: test return key length is correct
+        prk = b"pseudorandomkey"
+        info=b"makis"
+
+        key = hkdf_expand(prk, info, 5, "sha256")
+        self.assertEqual(key, HKDF(hashes.SHA256(), 5, prk, info).derive(info))
+
+
 
 
     # TODO: add test cases for HKDF
     def test_hkdf(self):
         """Test that hkdf function returns the expected key."""
-        # TODO: implement test cases for hkdf function
+
 
 
 if __name__ == "__main__":

--- a/crypto_labs/tests/test_hkdf.py
+++ b/crypto_labs/tests/test_hkdf.py
@@ -10,6 +10,12 @@ import unittest
 class TestHKDF(unittest.TestCase):
     """Test case for HKDF module."""
 
+
+    def test_hkdf_extract(self):
+        """Test that hkdf_extract function returns the expected key."""
+        # TODO: test return key length is correct
+
+
     # TODO: add test cases for HKDF
     def test_hkdf(self):
         """Test that hkdf function returns the expected key."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,50 +36,6 @@ toml = ["tomli (>=1.1.0)"]
 yaml = ["PyYAML"]
 
 [[package]]
-name = "black"
-version = "24.10.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
-    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
-    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
-    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
-    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
-    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
-    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
-    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
-    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
-    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
-    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
-    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
-    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
-    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
-    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cffi"
 version = "1.17.1"
 description = "Foreign Function Interface for Python calling C code."
@@ -157,20 +113,6 @@ files = [
 
 [package.dependencies]
 pycparser = "*"
-
-[[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -334,28 +276,6 @@ python-versions = ">=3.7"
 files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
-name = "packaging"
-version = "24.2"
-description = "Core utilities for Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
 
 [[package]]
@@ -634,4 +554,4 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4ac095f812130a82f636b7f8da6f62a9fafed58d46db71477b65d5546ed571a5"
+content-hash = "49cc8f8aa59385e13e9459734e6e312a129e5da8484778c6b9069e81a6cc04e9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,6 +80,85 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
+    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
+    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
+    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
+    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
+    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
+    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
+    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
+    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
+    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
+    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
+    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
+    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
+    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
+    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -103,6 +182,57 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "cryptography"
+version = "44.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
+files = [
+    {file = "cryptography-44.0.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:84111ad4ff3f6253820e6d3e58be2cc2a00adb29335d4cacb5ab4d4d34f2a123"},
+    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b15492a11f9e1b62ba9d73c210e2416724633167de94607ec6069ef724fad092"},
+    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:831c3c4d0774e488fdc83a1923b49b9957d33287de923d58ebd3cec47a0ae43f"},
+    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb"},
+    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b"},
+    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543"},
+    {file = "cryptography-44.0.0-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:60eb32934076fa07e4316b7b2742fa52cbb190b42c2df2863dbc4230a0a9b385"},
+    {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e"},
+    {file = "cryptography-44.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e"},
+    {file = "cryptography-44.0.0-cp37-abi3-win32.whl", hash = "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053"},
+    {file = "cryptography-44.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:abc998e0c0eee3c8a1904221d3f67dcfa76422b23620173e28c11d3e626c21bd"},
+    {file = "cryptography-44.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:660cb7312a08bc38be15b696462fa7cc7cd85c3ed9c576e81f4dc4d8b2b31591"},
+    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1923cb251c04be85eec9fda837661c67c1049063305d6be5721643c22dd4e2b7"},
+    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:404fdc66ee5f83a1388be54300ae978b2efd538018de18556dde92575e05defc"},
+    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289"},
+    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7"},
+    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c"},
+    {file = "cryptography-44.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9abcc2e083cbe8dde89124a47e5e53ec38751f0d7dfd36801008f316a127d7ba"},
+    {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64"},
+    {file = "cryptography-44.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285"},
+    {file = "cryptography-44.0.0-cp39-abi3-win32.whl", hash = "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417"},
+    {file = "cryptography-44.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:708ee5f1bafe76d041b53a4f95eb28cdeb8d18da17e597d46d7833ee59b97ede"},
+    {file = "cryptography-44.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:37d76e6863da3774cd9db5b409a9ecfd2c71c981c38788d3fcfaf177f447b731"},
+    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f677e1268c4e23420c3acade68fac427fffcb8d19d7df95ed7ad17cdef8404f4"},
+    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f5e7cb1e5e56ca0933b4873c0220a78b773b24d40d186b6738080b73d3d0a756"},
+    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:8b3e6eae66cf54701ee7d9c83c30ac0a1e3fa17be486033000f2a73a12ab507c"},
+    {file = "cryptography-44.0.0-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:be4ce505894d15d5c5037167ffb7f0ae90b7be6f2a98f9a5c3442395501c32fa"},
+    {file = "cryptography-44.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:62901fb618f74d7d81bf408c8719e9ec14d863086efe4185afd07c352aee1d2c"},
+    {file = "cryptography-44.0.0.tar.gz", hash = "sha256:cd4e834f340b4293430701e772ec543b0fbe6c2dea510a5286fe0acabe153a02"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==44.0.0)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dill"
@@ -275,6 +405,17 @@ python-versions = ">=3.8"
 files = [
     {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
     {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]
@@ -493,4 +634,4 @@ dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4a26a7907631b110e414c09d279f298d4367dece67d37939033c9c37a15c74b8"
+content-hash = "4ac095f812130a82f636b7f8da6f62a9fafed58d46db71477b65d5546ed571a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ cryptography = "^44.0.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.7.4"
-black = "^24.10.0"
 invoke = "^2.2.0"
 toml = "^0.10.2"
 flake8 = "^7.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
+cryptography = "^44.0.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tasks.py
+++ b/tasks.py
@@ -43,13 +43,6 @@ def lock(context, check=False):
 
 
 @task
-def black(context):
-    """Run black to check that Python files adherence to black standards."""
-    exec_cmd = "black --check --diff ."
-    run_command(context, exec_cmd)
-
-
-@task
 def flake8(context):
     """Run flake8 code analysis."""
     exec_cmd = "flake8 . --config .flake8"
@@ -139,7 +132,6 @@ def unittest(context, test_case=None, verbose=False):
 @task()
 def tests(context):
     """Run all tests for this repository."""
-    black(context)
     flake8(context)
     pylint(context)
     yamllint(context)


### PR DESCRIPTION
Implementation of HKDF expand and extract functions based on RFC 5869.
Run against the test vectors found in the same doc and passed. 
Bytes and bytearrays representation of strings in python is a bit tricky 